### PR TITLE
feat: handle `file://` prefix for wallpaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,5 @@ Options:
 
 See [config example](config-example/config.json) for supported fields & options.
 
-**Note**: Path to wallpaper must be prepended with `file://` prefix. `gsettings` (which is used underneath) requires it and I did not write any better validation / automatic prefix prepending yet.
-
-[Tracking issue](https://github.com/kkafar/theme-manager/issues/28)
-
 
 **Note**: `kitty` param in theme specification is optional (rest of them are required) - it is option for setting theme of terminal emulator of my choice.

--- a/src/gsettings.rs
+++ b/src/gsettings.rs
@@ -123,10 +123,10 @@ impl Gsettings {
   }
 
   fn set_wallpaper(&self, path: &str) {
-		let mut sanitized_path: String = path.to_owned();
-		if !path.starts_with("file://") {
-			sanitized_path = "file://".to_owned() + path;
-		}
+    let mut sanitized_path: String = path.to_owned();
+    if !path.starts_with("file://") {
+      sanitized_path = "file://".to_owned() + path;
+    }
 
     let result = Command::new("gsettings")
       .arg("set")

--- a/src/gsettings.rs
+++ b/src/gsettings.rs
@@ -123,11 +123,16 @@ impl Gsettings {
   }
 
   fn set_wallpaper(&self, path: &str) {
+		let mut sanitized_path: String = path.to_owned();
+		if !path.starts_with("file://") {
+			sanitized_path = "file://".to_owned() + path;
+		}
+
     let result = Command::new("gsettings")
       .arg("set")
       .arg("org.cinnamon.desktop.background")
       .arg("picture-uri")
-      .arg(path)
+      .arg(sanitized_path)
       .env(DBUS_SESSION_BUS_ADDRESS_KEY, &self.dbus_session_bus_address)
       .status();
 


### PR DESCRIPTION
It is no longer needed, to prepend path to a wallpaper with `file://` prefix in configuration file.

Resolves #28 